### PR TITLE
fix: resolve program initialization stalling at proxy check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # HTTP and WebSocket clients
 aiohttp>=3.8.0
 websockets>=10.0
+brotli>=1.0.9  # For HTTP compression
 
 # Proxy support
 aiohttp-socks>=0.7.1


### PR DESCRIPTION
## Root Cause
The stalling occurred because the application was unable to properly decompress HTTP responses during the initial connection phase, as the required `brotli` package was missing from dependencies.

## Changes Made
- Added `brotli>=1.0.9` to `requirements.txt` for HTTP compression handling
- Location: Under "HTTP and WebSocket clients" section alongside `aiohttp`

## How to Test
1. Clean install of dependencies: `pip install -r requirements.txt`
2. Run the program: `python new.py`
3. Verify that the program successfully progresses past the proxy check stage
4. Test with both proxy and no-proxy configurations

## Breaking Changes
⚠️ Users will need to run `pip install -r requirements.txt` to install the new required dependency.

## Related Issues
- Fixes program stalling at startup
- Enables proper execution flow in new.py after proxy initialization

## Additional Notes
The `brotli` package is essential for handling compressed HTTP responses during the connection phase. Without it, the program cannot properly process responses and stalls.